### PR TITLE
 fixed permission issue of builddefs.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ctags:
 generated_headers: builddefs.h
 
 builddefs.h:
-	./builddefs.sh
+	$(SHELL) ./builddefs.sh
 
 proj: 	$(PROJ_NAME).elf
 


### PR DESCRIPTION
/F4OS$ make
./builddefs.sh
make: execvp: ./builddefs.sh: Permission denied
make: **\* [builddefs.h] Error 127
