### PR TITLE
Fix build failure on Mac OS X due to formatted wc output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -nostdlib -ffreestanding
 CFLAGS += -Wdouble-promotion -fsingle-precision-constant -fshort-double
 
 DATE := "$(shell date -u)"
-REV := $(shell git rev-list HEAD | wc -l)
+REV := $(shell git rev-list HEAD | wc -l | tr -d ' ')
 CFLAGS += -D BUILD_TIME='$(DATE)' -D BUILD_REV=$(REV)
 
 #CFLAGS += -save-temps --verbose -Xlinker --verbose


### PR DESCRIPTION
When building on my Mac OS X, REV gets the value of $(git rev-list HEAD | wc -l), which is formatted with spaces before the number, so i ends up being something like:

REV=      971

which fails. This patch just removes any spaces on the output of $(wc -l) so that REV get only the integer value.
